### PR TITLE
Add dummy model for server testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,13 @@ http://127.0.0.1:8000/ping
 ```
 
 This endpoint returns a simple `pong` message, indicating that the server is healthy and ready to process requests.
+
+## Testing the Dummy Model
+
+To run tests for the dummy model, navigate to the project directory and execute the following command:
+
+```
+python -m unittest test/test_server.py
+```
+
+This command will run the tests defined in `test_server.py`, testing the dummy model with both numeric and string inputs to ensure it behaves as expected.

--- a/model/model_loader.py
+++ b/model/model_loader.py
@@ -5,7 +5,7 @@ import torch
 def load_model(model_type: str, model_path: str):
     """
     Load a model based on its type and file path.
-    Supports sklearn, xgboost, and PyTorch models.
+    Supports sklearn, xgboost, PyTorch models, and a dummy model.
     """
     if model_type == 'sklearn':
         return joblib.load(model_path)
@@ -15,5 +15,8 @@ def load_model(model_type: str, model_path: str):
         model = torch.load(model_path)
         model.eval()
         return model
+    elif model_type == 'dummy':
+        from test.model.dummy_model import DummyModel
+        return DummyModel()
     else:
         raise ValueError("Unsupported model type")

--- a/test/model/dummy_model.py
+++ b/test/model/dummy_model.py
@@ -1,0 +1,6 @@
+class DummyModel:
+    def predict(self, input_data):
+        if isinstance(input_data, (int, float)):
+            return input_data ** 2
+        else:
+            return "Error: Input must be numeric."

--- a/test/test_server.py
+++ b/test/test_server.py
@@ -1,0 +1,13 @@
+import pytest
+from test.model.dummy_model import DummyModel
+
+def test_dummy_model_predict_with_numeric_input():
+    model = DummyModel()
+    assert model.predict(4) == 16
+    assert model.predict(0) == 0
+    assert model.predict(-3) == 9
+
+def test_dummy_model_predict_with_string_input():
+    model = DummyModel()
+    assert model.predict("string") == "Error: Input must be numeric."
+


### PR DESCRIPTION
Related to #3

This pull request introduces a dummy model for testing server implementation, updates the model loader to support the dummy model, and adds instructions for running tests.

- **Dummy Model Implementation**
  - Adds a new file `test/model/dummy_model.py` containing the `DummyModel` class with a `predict` method. This method squares numeric inputs and returns an error message for non-numeric inputs.
- **Model Loader Update**
  - Modifies `model/model_loader.py` to include a condition for loading the `DummyModel` when the `model_type` is 'dummy'.
- **Testing**
  - Adds a new file `test/test_server.py` for testing the dummy model with both numeric and string inputs, ensuring correct behavior.
- **Documentation**
  - Updates `README.md` with a new section on how to run tests for the dummy model, including the command to execute the tests.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/eugeneyan/workspace-testing/issues/3?shareId=354548ab-4c3c-482c-aeb2-8f30eb2a5f93).