### PR TITLE
Fix pytest import error in test_server.py

### DIFF
--- a/test/test_server.py
+++ b/test/test_server.py
@@ -1,5 +1,5 @@
 import pytest
-from test.model.dummy_model import DummyModel
+from ..model.dummy_model import DummyModel
 
 def test_dummy_model_predict_with_numeric_input():
     model = DummyModel()
@@ -10,4 +10,3 @@ def test_dummy_model_predict_with_numeric_input():
 def test_dummy_model_predict_with_string_input():
     model = DummyModel()
     assert model.predict("string") == "Error: Input must be numeric."
-


### PR DESCRIPTION
Related to #7

Fixes the pytest error by correcting the import path in `test/test_server.py`.

- Updates the import statement to use a relative path for `DummyModel`, changing from `from test.model.dummy_model import DummyModel` to `from ..model.dummy_model import DummyModel`. This resolves the module import failure and aligns with Python's module import conventions.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/eugeneyan/workspace-testing/issues/7?shareId=d58c4f6f-d9f7-4c52-97cc-642a5c9142a6).